### PR TITLE
fix update chart

### DIFF
--- a/frontend/src/components/Charts/CandlestickChart.vue
+++ b/frontend/src/components/Charts/CandlestickChart.vue
@@ -15,14 +15,11 @@
   </label>
   <apexchart
     ref="theChart"
-    :options="data.chartOptions"
-    :series="data.series"
+    :options="chartOptions"
+    :series="series"
     height="350"
     type="candlestick"
   />
-
-  <!--  @todo If you remove this, charts wont update-->
-  <small>{{ data.series }}</small>
 </template>
 
 <script lang="ts">
@@ -46,38 +43,38 @@ export default defineComponent({
     const theChart     = ref(null)
     const currentScale = ref(30)
 
-    const data = reactive({
-      chartOptions: {
-        chart: {
-          type   : 'candlestick',
-          height : 350
-        },
-        xaxis: {
-          type: 'datetime'
-        },
-        yaxis: {
-          tooltip: {
-            enabled: true
-          }
-        }
+    const chartOptions = reactive({
+      chart: {
+        type   : 'candlestick',
+        height : 350
       },
-      series: [
+      xaxis: {
+        type: 'datetime'
+      },
+      yaxis: {
+        tooltip: {
+          enabled: true
+        }
+      }
+    })
+
+    const series = ref(
+      [
         {
           name : 'series-1',
           data : []
-        },
-      ],
-    })
+        }
+      ]
+    )
 
     const updateSeriesLine = (data) => {
       console.log(theChart.value)
 
-      data.series[0].data = data
+      series.value[0].data = data
       //   theChart.value.$forceUpdate()
 
 
     }
-
 
     const loadData = async () => {
       const eod = await Parse.Cloud.run('Assets--GetEndOfDay', {
@@ -87,15 +84,23 @@ export default defineComponent({
         assetSymbol : props.assetSymbol.toPointer()
       })
 
-      data.series[0].data = reactive(eod.map(elem => {
+      const ohlc: CandlestickSeries[] = eod.map(elem => {
         return {
           x : new Date(elem.date),
           y : [
             elem.open, elem.open, elem.low, elem.close
           ]
         } as CandlestickSeries
-      }))
-      console.log(data.series[0].data)
+      })
+
+      series.value = [
+        {
+          name : 'series-1',
+          data : ohlc
+        }
+      ]
+
+      console.log(series.value[0].data)
       //  updateSeriesLine(data)
     }
 
@@ -120,10 +125,11 @@ export default defineComponent({
     })
 
     return {
+      chartOptions,
+      series,
       theChart,
       timeScales,
       currentScale,
-      data,
     }
   },
 })


### PR DESCRIPTION
I have split the series array into another ref constant and explicitly updated the series.value. This fixes the update issue, but I am not sure why it had problems before. As far as I understood the `reactive` wrapping function should make everything in that object reactive.

ApexCharts has a little notice about something like this:
![image](https://user-images.githubusercontent.com/35574021/112129081-51ad5980-8bc7-11eb-837e-e347f94fce70.png)

Would still be nice to know what the problem is here.